### PR TITLE
Pass custom_package passed to kt_android_library to android_library

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -53,4 +53,5 @@ def kt_android_library(name, exports = [], visibility = None, **kwargs):
         exports = exports + _kt_android_artifact(name, **kwargs),
         visibility = visibility,
         testonly = kwargs.get("testonly", default = 0),
+        custom_package = kwargs.get("custom_package", default = None),
     )


### PR DESCRIPTION
This allow user of those rules to decide what the package going to be and avoid android rules to try to figure out packe name on their own - which sometimes would be incorrect/invalid name - for instance containing `-`.